### PR TITLE
Remove semicolon from #include "MemoryFree.h";

### DIFF
--- a/MemoryFree.cpp
+++ b/MemoryFree.cpp
@@ -20,7 +20,7 @@ struct __freelist
 /* The head of the free list structure */
 extern struct __freelist *__flp;
 
-#include "MemoryFree.h";
+#include "MemoryFree.h"
 
 /* Calculates the size of the free list */
 int freeListSize()


### PR DESCRIPTION
The semicolon causes a compiler warning.
