### PR TITLE
Replaced 'int' type with 'intptr_t' type in pointer arithmetic for co…

### DIFF
--- a/MemoryFree.cpp
+++ b/MemoryFree.cpp
@@ -4,6 +4,8 @@
 #include <WProgram.h>
 #endif
 
+#include <stdint.h>
+
 extern unsigned int __heap_start;
 extern void *__brkval;
 
@@ -39,13 +41,13 @@ int freeListSize()
 int freeMemory()
 {
   int free_memory;
-  if ((int)__brkval == 0)
+  if ((intptr_t)__brkval == 0)
   {
-    free_memory = ((int)&free_memory) - ((int)&__heap_start);
+    free_memory = ((intptr_t)&free_memory) - ((intptr_t)&__heap_start);
   }
   else
   {
-    free_memory = ((int)&free_memory) - ((int)__brkval);
+    free_memory = ((intptr_t)&free_memory) - ((intptr_t)__brkval);
     free_memory += freeListSize();
   }
   return free_memory;

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ This is the excellent MemoryFree library from http://www.arduino.cc/playground/C
 I am hosting it here so there is a quick and easy way to pull it down.
 
 (20 Mar 2015) Repository updated with code from http://playground.arduino.cc/code/AvailableMemory
+(17 Jan 2021) Replaced 'int' type with 'intptr_t' type in pointer arithmetic for compiling without -fpermisive


### PR DESCRIPTION
Compiler yabs about losing precision:

~/Arduino/libraries/MemoryFree/src/MemoryFree.cpp:44:7: error: cast from 'void*' to 'int' loses precision [-fpermissive]

Using intptr_t type (as per C99 I believe) is recommended because it guarantees to hold the size of a pointer.

The Arduino IDE compiles with -fpermisive by default, but continuous integration frameworks like Arduino-CI and Cmake/Makefile type compilation does not.

Tested in Arduino-CI and on an Arduino Mega2560.